### PR TITLE
Generalized Cheat Sheet for user sheets to be added.

### DIFF
--- a/CheatSheet.tmLanguage
+++ b/CheatSheet.tmLanguage
@@ -12,15 +12,21 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>\A\w+$</string>
+			<string>^.*  </string>
+			<key>name</key>
+			<string>entity.name.function</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\t.*</string>
 			<key>name</key>
 			<string>markup.heading.2</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\A\S+\s</string>
+			<string>^.*</string>
 			<key>name</key>
-			<string>entity.name.function</string>
+			<string>variable.parameter</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cheater.py
+++ b/Cheater.py
@@ -1,21 +1,39 @@
+from os.path import dirname, exists, join, realpath
 import sublime, sublime_plugin
-from os.path import dirname, realpath, join
+import string
 
 MY_PLUGIN_DIR = dirname(realpath(__file__))
 
-class RegExCheatSheetCommand(sublime_plugin.WindowCommand):
-  def run(self):
-    dest_view = self.window.open_file(join(MY_PLUGIN_DIR,'cheat_sheets/Regular Expressions.cheatsheet'))
+class CheatSheetCommand(sublime_plugin.WindowCommand):
+  def run(self, **args):
+    sheetName = args["cheatsheet"] + ".cheatsheet"
+    userSheet = join(sublime.packages_path(), "User/cheat_sheets", sheetName)
+    defaultSheet = join(MY_PLUGIN_DIR,"cheat_sheets", sheetName)
+
+    if exists(userSheet):
+      sheet = userSheet
+    elif exists(defaultSheet):
+      sheet = defaultSheet
+    dest_view = self.window.open_file(sheet)
 
     def set_view_props():
       if dest_view.is_loading():
         sublime.set_timeout(set_view_props, 50)
         return
 
-      dest_view.set_name('RegEx Cheat Sheet')
-      dest_view.set_syntax_file(join(MY_PLUGIN_DIR,'CheatSheet.tmLanguage'))
-      dest_view.set_scratch(True)
-      dest_view.set_read_only(True)
-
     set_view_props()
     self.dest_view = dest_view
+
+class CheatSheetTesterCommand(sublime_plugin.TextCommand):  
+  def run(self, edit, **args):  
+    sheetName = args["cheatsheet"] + ".cheatsheet"
+    userSheet = join(sublime.packages_path(), "User/cheat_sheets", sheetName)
+    defaultSheet = join(MY_PLUGIN_DIR,"cheat_sheets", sheetName)
+    
+    for value in userSheet, defaultSheet:
+      if exists(value):
+        print("File found:     %s" % value)
+      else:
+        print("File not found: %s" % value)
+
+

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,4 @@
 [
-  {   
-    "keys": ["ctrl+shift+c", "r", "x"], "command": "reg_ex_cheat_sheet"   
-  }
-]  
+  { "keys": ["ctrl+shift+c", "r", "x"], "command": "cheat_sheet", "args": {"cheatsheet": "Regular Expressions"} },
+  { "keys": ["ctrl+shift+c", "r", "y"], "command": "cheat_sheet_tester", "args": {"cheatsheet": "Regular Expressions"} }
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,4 @@
 [
-  {   
-    "keys": ["super+shift+c", "r", "x"], "command": "reg_ex_cheat_sheet"   
-  }
-]  
+  { "keys": ["super+shift+c", "r", "x"], "command": "cheat_sheet", "args": {"cheatsheet": "Regular Expressions"} },
+  { "keys": ["super+shift+c", "r", "y"], "command": "cheat_sheet_tester", "args": {"cheatsheet": "Regular Expressions"} }
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,4 @@
 [
-  {   
-    "keys": ["ctrl+shift+c", "r", "x"], "command": "reg_ex_cheat_sheet"   
-  }
-]  
+  { "keys": ["ctrl+shift+c", "r", "x"], "command": "cheat_sheet", "args": {"cheatsheet": "Regular Expressions"} },
+  { "keys": ["ctrl+shift+c", "r", "y"], "command": "cheat_sheet_tester", "args": {"cheatsheet": "Regular Expressions"} }
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,17 +1,18 @@
-[  
-{  
-    "id": "tools",  
-    "children":  
-    [  
-        {"id": "cheat-sheets", 
-         "caption": "Cheat Sheets",
-         "children":
-          [
-            {"id": "regular-expressions"},
-            {"caption": "Regular Expressions"},
-            { "command": "reg_ex_cheat_sheet" }
-          ]
-        } 
-    ]  
-}  
-]  
+[
+  {
+    "id": "tools",
+    "children": [
+      {
+        "id": "cheat-sheets",
+        "caption": "Cheat Sheets",
+        "children": [
+          {
+            "caption": "Regular Expressions",
+            "command": "cheat_sheet",
+            "args": {"cheatsheet": "Regular Expressions"}
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,46 @@ Cheater is a plugin for quickly accessing cheat sheets in the Sublime Text 2 edi
 
 At the moment there is only one available sheet.
 
-* Regular Expressions (cmd/ctrl + shift + c) (once) + r + x
+* Regular Expressions "cmd/ctrl + shift + c" + "r" + "x"
+
+## How to add your own Cheat Sheets
+
+* In your `./Packages/User/` folder create a folder named `cheat_sheet` and add your filename.cheatsheet. Highlighting follows the following format:
+
+```
+Header
+\t Text
+Command \s\s Text
+```
+
+* Add a keyboard shortcut by adding the following line to `./Packages/User/Default(OS).sublime-keymap` and change the keys and filename:
+
+```
+{ "keys": ["ctrl+shift+c", "n", "s"], "command": "cheat_sheet", "args": {"cheatsheet": "filename"} }
+```
+
+* Add a menu entry by adding the following to `./Packages/User/Main.sublime-menu and change both instances of filename:
+
+```
+[
+  {
+    "id": "tools",
+    "children": [
+      {
+        "id": "cheat-sheets",
+        "caption": "Cheat Sheets",
+        "children": [
+          {
+            "caption": "filename",
+            "command": "cheat_sheet",
+            "args": {"cheatsheet": "filename"}
+          }
+        ]
+      }
+    ]
+  }
+]
+```
 
 ## Note on Patches/Pull Requests
 

--- a/cheat_sheets/Regular Expressions.cheatsheet
+++ b/cheat_sheets/Regular Expressions.cheatsheet
@@ -3,42 +3,42 @@ Anchors
 ^      Start of current line
 $      End of current line, except for a trailing line break
 \A     Start of current string
-\Z     End of current string, except for a trailing line break  
+\Z     End of current string, except for a trailing line break
 \z     Absolute end of the current string
 
 Characters
 
-a     Any character, except those described below, matches itself, once.
-\     Escape for the characters below. Maches one instance of the 
-      characterh that follows the \
-\x00  Where 00 are 2 hexadecimal digits. Matches the character with the
-      ANSI/ASCII value specified by the hexadecimnal digits.
-\n    Line feed character
-\r    Carriage return character
-\t    Tab character
-\cA   Where A is A-Z, matches Control+A through Control+Z
-.     Any single character
+a      Any character, except those described below, matches itself, once.
+\      Escape for the characters below. Maches one instance of the
+       characterh that follows the \
+\x00   Where 00 are 2 hexadecimal digits. Matches the character with the
+       ANSI/ASCII value specified by the hexadecimnal digits.
+\n     Line feed character
+\r     Carriage return character
+\t     Tab character
+\cA    Where A is A-Z, matches Control+A through Control+Z
+.      Any single character
 
 Quantifiers
 
-?     Makes the preceding term is optional
-*     Matches the previous item 0 or more times, so it always matches something
-*?    Lazy version of the aboves, matches as few characters as possible
-+     Matches the previous item 1 or more times
-+?    Lazy version of the above, matches as few characters as possible
-{n}   Matches the previous item exactly n times.
-{n,m} Matches the previous item between n and m times. A ? makes it lazy.
-{n,}  Matches the previous item n or more times. A ? makes it lazy.
+?      Makes the preceding term is optional
+*      Matches the previous item 0 or more times, so it always matches something
+*?     Lazy version of the aboves, matches as few characters as possible
++      Matches the previous item 1 or more times
++?     Lazy version of the above, matches as few characters as possible
+{n}    Matches the previous item exactly n times.
+{n,m}  Matches the previous item between n and m times. A ? makes it lazy.
+{n,}   Matches the previous item n or more times. A ? makes it lazy.
 
 Character Sets
 
-[abc] Matches a single instance of a or b or c
-[a-e] Matches a single instance of a character between a and c
-^[ab] Matches a single instance of any character except a and b
-\d    Any single digit character
-\w    Any single word chracter, leters, digits and underscores
-\s    Any single whitespace character
-\D    Any single character thas is not a digit
-\W    Any single character that not a word character
-\S    Any single character that is not whitespace
+[abc]  Matches a single instance of a or b or c
+[a-e]  Matches a single instance of a character between a and c
+^[ab]  Matches a single instance of any character except a and b
+\d     Any single digit character
+\w     Any single word chracter, leters, digits and underscores
+\s     Any single whitespace character
+\D     Any single character thas is not a digit
+\W     Any single character that not a word character
+\S     Any single character that is not whitespace
 

--- a/cheat_sheets/Sublime Text.cheatsheet
+++ b/cheat_sheets/Sublime Text.cheatsheet
@@ -1,0 +1,111 @@
+Sublime Text 2 Cheat Sheet
+  This is a cheat sheet with keyboard shortcuts for Sublime Text 2.
+
+Backups
+Ctrl + Alt + [         Navigate backwards through history
+Ctrl + Alt + ]         Navigate forwards through history
+Ctrl + Alt + Shft + [  Navigate to beginning of history
+Ctrl + Alt + Shft + ]  Navigate to end of history
+Ctrl + Alt + Shft + M  Merge selected version with current version
+
+General
+Ctrl + B               Build file
+Ctrl + Shft + B        Test file
+Ctrl + Shft + P        Open command palette
+Ctrl + S               Save file
+Ctrl + Shft + S        Save file as
+
+Plugins
+Alt + ;                Align table with Regular Expressions
+Ctrl + Alt + J         Align JSON formatting
+Text
+ Editing
+Ctrl + C               Copy seletcion or whole line
+Ctrl + V               Paste and indent
+Ctrl + X               Cut selection or whole line
+
+Ctrl + Shft + F        Replace in multiple files
+Ctrl + Shft + D        Duplicate line
+Ctrl + J               Join next line with current line
+Ctrl + K + K           Delete to the end of line
+Ctrl + K + Bksp        Delete to start of line
+Ctrl + Shft + K        Delete line
+Ctrl + T               Transpose letters adjacent to cursor
+Ctrl + Shft + U        Soft undo
+Ctrl + Shft + U        Soft redo
+Ctrl + Shft + Y        Redo
+Ctrl + Shft + Z        Undo
+Ctrl + [               Increase tab
+Ctrl + ]               Decrease tab
+Ctrl + Shft + /        Toggle comments on selected lines
+Ctrl + Shft + Entr     Insert line after
+Ctrl + Shft + Entr     Insert line before
+Ctrl + Shft + Up       Move line up
+Ctrl + Shft + Down     Move line down
+Ctrl + Bksp            Delete to begginning of word
+Ctrl + Del             Delete to end of word
+
+Text Navigation
+Ctrl + F               Find
+Ctrl + F3              Find next
+Ctrl + Shft + F3       Find previous
+Ctrl + F, Alt + C      Toggle case sensitivity in Find
+Ctrl + F, Alt + R      Toggle RegEx in Find
+Ctrl + F, Alt + W      Toggle whole word matching in Find
+Ctrl + Shft + F        Find in files
+Ctrl + H               Replace
+Ctrl + K + C           Move to cursor
+Ctrl + K + 1-9         Fold to level 1-9
+Ctrl + K + J           Unfold all
+Ctrl + M               Jump to matching bracket
+Ctrl + P               Go to anything
+Ctrl + G               Go to line number
+Ctrl + R               Go to function
+Ctrl + ;               Go to word
+Ctrl + Shft + P        Open command pallette
+
+F5                     Next bookmark
+Shft + F5              Previous bookmark
+Ctrl + F5              Toggle bookmark
+Alt + F5               Select all bookmarks
+Ctrl + Shft + F5       Clear all bookmarks
+
+Ctrl + Shft + [        Fold code
+Ctrl + Shft + ]        Unfold code
+
+Text Selection
+Ctrl + A               Select all
+Ctrl + D               Repeat multi-­select word
+Alt + D                Select all instances of word
+Ctrl + Shft + J        Expand selection to indentation
+Ctrl + K               Skip multi-­select word
+Ctrl + L               Select current line
+Ctrl + Shft + M        Select everything within the current brackets
+Ctrl + Shft + U        Undo selection and actions
+Ctrl + Shft + Spce     Expand selection to scope
+Ctrl + Clck            Make multiple selections with mouse
+
+Window Navigation
+Ctrl + K + B           Toggle side-bar
+Ctrl + K + M           Toggle mini-map
+Ctrl + N               Open new tab
+Ctrl + Shft + N        Open new window
+Ctrl + Alt + P         Switch to recent project
+
+Alt + Shft + 1         Switch to 1 column and 1 row layout
+Alt + Shft + 2         Switch to 2 column layout
+Alt + Shft + 3         Switch to 3 column layout
+Alt + Shft + 4         Switch to 4 column layout
+Alt + Shft + 5         Switch to 2 column and 2 row layout
+Alt + Shft + 8         Switch to 2 row layout
+Alt + Shft + 9         Switch to 3 row layout
+
+Ctrl + Shft + 1        Focus on group 1
+Ctrl + Shft + 2        Focus on group 2
+Ctrl + Shft + 3        Focus on group 3
+Ctrl + Shft + 4        Focus on group 4
+
+Ctrl + Tab             Switch to the next tab
+Ctrl + Shft + Tab      Switch to the previous tab
+
+Shft + F11             Distra­ction free mode


### PR DESCRIPTION
Cheat sheets can now be added to ./Packages/Users/cheat_sheets/filename.cheatsheet.

ST commands are now issued as `"command": "cheat_sheet", "args": {"cheatsheet": "filename"}` and there is a similar cheat_sheet_tester that will print whether or not filename could be found to the ST console.

I changed the highlighting and fixed a bug highlighting sections with spaces, and updated all the other files where necessary.
